### PR TITLE
bump: opentelemetry to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 bitcoin = { version= "0.32.0", features = ["std"], default-features = false }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }
-opentelemetry = { version = "0.26.0", features = ["trace"], default-features = false }
+opentelemetry = { version = "0.27.0", features = ["trace"], default-features = false }
 tokio = { version = "1.12.0", features = ["rt", "macros"], default-features = false }


### PR DESCRIPTION
# Description
otel changelog: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#0270